### PR TITLE
fix namespace in validation class

### DIFF
--- a/src/Validation.php
+++ b/src/Validation.php
@@ -29,6 +29,6 @@ class Validation
      */
     public function getValidationFactory()
     {
-        return app(Illuminate\Contracts\Validation\Factory::class);
+        return app(\Illuminate\Contracts\Validation\Factory::class);
     }
 }


### PR DESCRIPTION
Add the missing `\` to the namespace in the Validation Class