### PR TITLE
Docblock fix

### DIFF
--- a/src/ServesFeaturesTrait.php
+++ b/src/ServesFeaturesTrait.php
@@ -13,8 +13,8 @@ trait ServesFeaturesTrait
     /**
      * Serve the given feature with the given arguments.
      *
-     * @param \Lucid\Foundation\AbstractFeature $feature
-     * @param array                           $arguments
+     * @param string $feature
+     * @param array  $arguments
      *
      * @return mixed
      */


### PR DESCRIPTION
This argument is passed to `marshal` which expects a string, so it must be a string.