### PR TITLE
Improve runInQueue method: ability to parse args by key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea/

--- a/src/JobDispatcherTrait.php
+++ b/src/JobDispatcherTrait.php
@@ -49,8 +49,12 @@ trait JobDispatcherTrait
     public function runInQueue($job, array $arguments = [], $queue = 'default')
     {
         // instantiate and queue the job
-        $reflection = new ReflectionClass($job);
-        $jobInstance = $reflection->newInstanceArgs($arguments);
+        if ($arguments instanceof Request) {
+            $jobInstance = $this->marshal($job, $arguments, []);
+        } else {
+            $jobInstance = $this->marshal($job, new Collection(), $arguments);
+        }
+
         $jobInstance->onQueue((string) $queue);
 
         return $this->dispatch($jobInstance);


### PR DESCRIPTION
Example of problem:

Run job in Feature
```
$this->runInQueue(MyJob::class, [
   'var3' => 'var3',
   'Var2' => 'var2',
    'Var1' => 'var1'
], 'q1');
```
 
Job
```
class MyJob extends Job implements ShouldQueue
{
      use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
      
      public function __construct($var1, $var2, $var3)
      {
            // var1 == var3, var2 == var2, var3 == 1
       }
}
```

Solution: use marshal