### PR TITLE
Allow alternative notation for constructor arguments in ServeFeaturesTrait

### DIFF
--- a/src/ServesFeaturesTrait.php
+++ b/src/ServesFeaturesTrait.php
@@ -20,6 +20,10 @@ trait ServesFeaturesTrait
      */
     public function serve($feature, $arguments = [])
     {
-        return $this->dispatch($this->marshal($feature, new Collection(), $arguments));
+        if (!is_object($feature)) {
+            return $this->dispatch($this->marshal($feature, new Collection(), $arguments));
+        } else {
+            return $this->dispatch($feature, $arguments);
+        }
     }
 }


### PR DESCRIPTION
The current implementation of ServeFeaturesTrait doesn't allow for the following:

```php
$output = $this->serve(new GetReachEstimateFeature($adAccount, $accessToken));
```

which is inconsistent with `JobDispatcherTrait` that offers 2 alternative styles of passing constructor arguments:

```php
$this->run(GetTotalReachEstimateJob::class, [
    'adAccount' => $adAccount,
    'accessToken' => $accessToken,
]);
```

and this:

```php
$this->run(new GetTotalReachEstimateJob($adAccount, $accessToken));
```

The proposed PR is supposed to fix that.