### PR TITLE
[5.4] Dispatch event for each started feature, operation and job

### DIFF
--- a/src/Events/FeatureStarted.php
+++ b/src/Events/FeatureStarted.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Lucid\Foundation\Events;
+
+class FeatureStarted
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * FeatureStarted constructor.
+     * @param  string  $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Events/FeatureStarted.php
+++ b/src/Events/FeatureStarted.php
@@ -10,11 +10,18 @@ class FeatureStarted
     public $name;
 
     /**
+     * @var array
+     */
+    public $arguments;
+
+    /**
      * FeatureStarted constructor.
      * @param  string  $name
+     * @param  array  $arguments
      */
-    public function __construct($name)
+    public function __construct($name, array $arguments = [])
     {
         $this->name = $name;
+        $this->arguments = $arguments;
     }
 }

--- a/src/Events/JobStarted.php
+++ b/src/Events/JobStarted.php
@@ -10,11 +10,18 @@ class JobStarted
     public $name;
 
     /**
+     * @var array
+     */
+    public $arguments;
+
+    /**
      * JobStarted constructor.
      * @param  string  $name
+     * @param  array  $arguments
      */
-    public function __construct($name)
+    public function __construct($name, array $arguments = [])
     {
         $this->name = $name;
+        $this->arguments = $arguments;
     }
 }

--- a/src/Events/JobStarted.php
+++ b/src/Events/JobStarted.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Lucid\Foundation\Events;
+
+class JobStarted
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * JobStarted constructor.
+     * @param  string  $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Events/OperationStarted.php
+++ b/src/Events/OperationStarted.php
@@ -10,11 +10,18 @@ class OperationStarted
     public $name;
 
     /**
+     * @var array
+     */
+    public $arguments;
+
+    /**
      * OperationStarted constructor.
      * @param  string  $name
+     * @param  array  $arguments
      */
-    public function __construct($name)
+    public function __construct($name, array $arguments = [])
     {
         $this->name = $name;
+        $this->arguments = $arguments;
     }
 }

--- a/src/Events/OperationStarted.php
+++ b/src/Events/OperationStarted.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Lucid\Foundation\Events;
+
+class OperationStarted
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * OperationStarted constructor.
+     * @param  string  $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/JobDispatcherTrait.php
+++ b/src/JobDispatcherTrait.php
@@ -34,11 +34,11 @@ trait JobDispatcherTrait
             }
 
             if ($job instanceof Operation) {
-                event(new OperationStarted(get_class($job)));
+                event(new OperationStarted(get_class($job), $arguments));
             }
 
             if ($job instanceof Job) {
-                event(new JobStarted(get_class($job)));
+                event(new JobStarted(get_class($job), $arguments));
             }
 
             $result = $this->dispatch($job, $arguments);

--- a/src/JobDispatcherTrait.php
+++ b/src/JobDispatcherTrait.php
@@ -2,6 +2,8 @@
 
 namespace Lucid\Foundation;
 
+use Lucid\Foundation\Events\JobStarted;
+use Lucid\Foundation\Events\OperationStarted;
 use ReflectionClass;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -29,6 +31,14 @@ trait JobDispatcherTrait
         } else {
             if (!is_object($job)) {
                 $job = $this->marshal($job, new Collection(), $arguments);
+            }
+
+            if ($job instanceof Operation) {
+                event(new OperationStarted(get_class($job)));
+            }
+
+            if ($job instanceof Job) {
+                event(new JobStarted(get_class($job)));
             }
 
             $result = $this->dispatch($job, $arguments);

--- a/src/ServesFeaturesTrait.php
+++ b/src/ServesFeaturesTrait.php
@@ -21,7 +21,7 @@ trait ServesFeaturesTrait
      */
     public function serve($feature, $arguments = [])
     {
-        event(new FeatureStarted($feature));
+        event(new FeatureStarted($feature, $arguments));
 
         return $this->dispatch($this->marshal($feature, new Collection(), $arguments));
     }

--- a/src/ServesFeaturesTrait.php
+++ b/src/ServesFeaturesTrait.php
@@ -4,6 +4,7 @@ namespace Lucid\Foundation;
 
 use Illuminate\Support\Collection;
 use Illuminate\Foundation\Bus\DispatchesJobs;
+use Lucid\Foundation\Events\FeatureStarted;
 
 trait ServesFeaturesTrait
 {
@@ -20,6 +21,8 @@ trait ServesFeaturesTrait
      */
     public function serve($feature, $arguments = [])
     {
+        event(new FeatureStarted($feature));
+
         return $this->dispatch($this->marshal($feature, new Collection(), $arguments));
     }
 }


### PR DESCRIPTION
This PR adds events for each dispatched feature, operation or job in order to comprehensively integrate lucid with distributed tracing facilities like Jaeger.

The example below uses [Vinelab/tracing-laravel](https://github.com/Vinelab/tracing-laravel) package:

```php
use Illuminate\Support\Facades\Event;
use Lucid\Foundation\Events\FeatureStarted;
use Lucid\Foundation\Events\OperationStarted;
use Lucid\Foundation\Events\JobStarted;

Event::listen(FeatureStarted::class, function (FeatureStarted $event) {
    $span = Trace::getRootSpan();
    $span->setName($event->name);
});

Event::listen(OperationStarted::class, function (OperationStarted $event) {
    $span = Trace::getRootSpan();
    $span->annotate($event->name);
});

Event::listen(JobStarted::class, function (JobStarted $event) {
    $span = Trace::getRootSpan();
    $span->annotate($event->name);
});
```

![image](https://user-images.githubusercontent.com/10194667/63440182-09044c00-c438-11e9-9df8-878721635de5.png)